### PR TITLE
feat:add supabase keepalive

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,0 +1,36 @@
+name: Supabase Keepalive
+
+on:
+  schedule:
+    - cron: '0 3 */3 * *'
+  workflow_dispatch:
+
+jobs:
+  prod-keepalive:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Call production keepalive endpoint
+        env:
+          PROD_APP_BASE_URL: ${{ secrets.PROD_APP_BASE_URL }}
+          PROD_KEEP_ALIVE_SECRET: ${{ secrets.PROD_KEEP_ALIVE_SECRET }}
+        run: |
+          curl --fail --show-error --silent \
+            --header "Authorization: Bearer ${PROD_KEEP_ALIVE_SECRET}" \
+            "${PROD_APP_BASE_URL}/api/internal/keepalive"
+
+  dev-keepalive:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Call development Supabase keepalive RPC
+        env:
+          DEV_SUPABASE_URL: ${{ secrets.DEV_SUPABASE_URL }}
+          DEV_SUPABASE_ANON_KEY: ${{ secrets.DEV_SUPABASE_ANON_KEY }}
+        run: |
+          curl --fail --show-error --silent \
+            --request POST \
+            --header "apikey: ${DEV_SUPABASE_ANON_KEY}" \
+            --header "Authorization: Bearer ${DEV_SUPABASE_ANON_KEY}" \
+            --header "Content-Type: application/json" \
+            "${DEV_SUPABASE_URL}/rest/v1/rpc/keepalive"

--- a/src/app/api/internal/keepalive/route.ts
+++ b/src/app/api/internal/keepalive/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { errorMessages } from '@/constants/error'
+import prisma from '@/utils/api/db'
+
+const keepAliveSecret = process.env.KEEP_ALIVE_SECRET
+
+function isAuthorized(request: NextRequest) {
+  if (!keepAliveSecret) {
+    throw new Error('KEEP_ALIVE_SECRET is not defined')
+  }
+
+  const authorizationHeader = request.headers.get('authorization')
+  const bearerToken = authorizationHeader?.startsWith('Bearer ')
+    ? authorizationHeader.slice('Bearer '.length)
+    : null
+  const cronSecret = request.headers.get('x-cron-secret')
+
+  return bearerToken === keepAliveSecret || cronSecret === keepAliveSecret
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    if (!isAuthorized(request)) {
+      return NextResponse.json(
+        {
+          error: {
+            code: 401,
+            message: errorMessages[401],
+          },
+        },
+        { status: 401 },
+      )
+    }
+
+    await prisma.$queryRaw`SELECT 1`
+
+    return NextResponse.json({
+      ok: true,
+      timestamp: new Date().toISOString(),
+    })
+  } catch (error) {
+    console.error('keepalive failed:', error)
+
+    return NextResponse.json(
+      {
+        error: {
+          code: 500,
+          message: errorMessages[500],
+        },
+      },
+      { status: 500 },
+    )
+  }
+}


### PR DESCRIPTION
This pull request introduces a keepalive mechanism to ensure the application's production and development environments remain active and responsive. It adds a scheduled GitHub Actions workflow to periodically ping keepalive endpoints, and implements a secure API route for the production keepalive check.

**Keepalive automation and endpoint:**

- **GitHub Actions workflow:** Adds a `.github/workflows/keepalive.yml` file that defines scheduled jobs to call keepalive endpoints for both production and development environments, using secure secrets for authentication.
- **Production keepalive API route:** Implements `src/app/api/internal/keepalive/route.ts`, a new API endpoint that verifies an authorization token before performing a simple database query to confirm system health, returning a timestamped response.
- **Authorization logic:** The new API route checks for a valid bearer token or cron secret in the request headers, using the `KEEP_ALIVE_SECRET` environment variable for security.