### PR TITLE
fix:update keepalive production url

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -12,12 +12,11 @@ jobs:
     steps:
       - name: Call production keepalive endpoint
         env:
-          PROD_APP_BASE_URL: ${{ secrets.PROD_APP_BASE_URL }}
           PROD_KEEP_ALIVE_SECRET: ${{ secrets.PROD_KEEP_ALIVE_SECRET }}
         run: |
           curl --fail --show-error --silent \
             --header "Authorization: Bearer ${PROD_KEEP_ALIVE_SECRET}" \
-            "${PROD_APP_BASE_URL}/api/internal/keepalive"
+            "https://accounting-app-six.vercel.app/api/internal/keepalive"
 
   dev-keepalive:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request updates the production keepalive workflow to use a hardcoded URL instead of a secret-based environment variable. This simplifies the configuration and ensures the keepalive request always targets the correct endpoint.

Most important change:

* Updated the production keepalive step in `.github/workflows/keepalive.yml` to use the hardcoded URL `https://accounting-app-six.vercel.app/api/internal/keepalive` instead of the `PROD_APP_BASE_URL` secret.