### PR TITLE
fix:allow keepalive through middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,7 +6,12 @@ import { verifyJwt } from '@/utils/api/jwt'
 
 const env = process.env.NODE_ENV
 const allowedOrigins = ['localhost:3000', 'accounting-app-six.vercel.app']
-const apiUrlsWithoutAuth = ['/api/auth/register', '/api/auth/login', '/api/auth/me']
+const apiUrlsWithoutAuth = [
+  '/api/auth/register',
+  '/api/auth/login',
+  '/api/auth/me',
+  '/api/internal/keepalive',
+]
 
 export async function middleware(req: NextRequest) {
   const origin = req.headers.get('host') ?? ''


### PR DESCRIPTION
This pull request updates the list of API endpoints that do not require authentication in the `src/middleware.ts` file. The main change is the addition of a new endpoint to the unauthenticated routes.

Authentication configuration:

* Added `'/api/internal/keepalive'` to the `apiUrlsWithoutAuth` array, allowing this endpoint to bypass authentication checks.